### PR TITLE
Allow single exec to parse complete input file

### DIFF
--- a/c/bed_access.c
+++ b/c/bed_access.c
@@ -41,7 +41,7 @@ int bed_access_get_bed_range_from_file_by_index(char *file_loc, int index, char 
   char rd[4096];
   int found = 0;
 	while(fgets(rd, 4096, bedf) != NULL){
-		check(rd != NULL,"Invalid line read in ignored region file.");
+		check(rd != NULL,"Invalid line read in region file.");
 		line_no++;
 		if (line_no != index) continue;
 		char *chr_nom = malloc(sizeof(char *));
@@ -67,4 +67,20 @@ int bed_access_get_bed_range_from_file_by_index(char *file_loc, int index, char 
 error:
 	if(bedf) fclose(bedf);
 	return 0;
+}
+
+int bed_access_get_lines_in_file(char *file_loc){
+  FILE *bedf = NULL;
+  int count_lines = 0;
+  bedf = fopen(file_loc,"r");
+  char filechar[40], chr;
+  chr = getc(bedf);
+  while (chr != EOF){
+    if (chr == '\n') {
+      count_lines = count_lines + 1;
+    }
+    chr = getc(bedf);
+  }
+  fclose(bedf); //close file.
+  return count_lines;
 }

--- a/c/bed_access.h
+++ b/c/bed_access.h
@@ -41,4 +41,6 @@ KHASH_MAP_INIT_STR(cod,uint64_t)
 
 int bed_access_get_bed_range_from_file_by_index(char *file_loc, int index, char **chr, int *start, int *stop);
 
+int bed_access_get_lines_in_file(char *file_loc);
+
 #endif


### PR DESCRIPTION
This appears to work as expected.

loci.bed (GRCh37)

```
$ cat ~/data/loci.bed 
1	50000	100000
1	100000	200000
```

Run each index in isolation:

```
$ context_counter -f /var/spool/data/GRCh37/ref/genome.fa -c 3 -s /var/spool/data/loci.bed -i 1 -o - | grep CTG
CTG	878
$ context_counter -f /var/spool/data/GRCh37/ref/genome.fa -c 3 -s /var/spool/data/loci.bed -i 2 -o - | grep CTG
CTG	1756
```

Total count = 2634

Run with `-i 0` (or absent):

```
$ context_counter -f /var/spool/data/GRCh37/ref/genome.fa -c 3 -s /var/spool/data/loci.bed -i 0 -o - | grep CTG
CTG	2634
```